### PR TITLE
Added Dockerfile and support for hosting frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.0-alpine as build
 WORKDIR /build
 
 # Copy project source files
-COPY . ./
+COPY PredictAPI/ ./
 
 # Restore, build & publish
 RUN dotnet restore
@@ -18,7 +18,7 @@ RUN dotnet publish --no-restore --configuration Release
 # =======================================================
 
 # Base image is .NET Core runtime only (Linux)
-FROM mcr.microsoft.com/dotnet/core/aspnetdoick:3.0-alpine
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.0-alpine
 
 # Metadata in Label Schema format (http://label-schema.org)
 LABEL org.label-schema.name    = "RomCom or Not RomCom" \
@@ -30,6 +30,9 @@ WORKDIR /app
 
 # Copy already published binaries (from build stage image)
 COPY --from=build /build/bin/Release/netcoreapp3.0/publish/ .
+
+# Host the frontend with the API, remove if you don't want this
+COPY frontend/ ./wwwroot
 
 # IMPORTANT! Kestrel will bind to localhost by default, which is no good inside a container!
 # See https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-3.0#endpoint-configuration

--- a/PredictAPI/Dockerfile
+++ b/PredictAPI/Dockerfile
@@ -1,0 +1,42 @@
+# =======================================================
+# Stage 1 - Build/compile API using SDK image
+# =======================================================
+
+# Build image has SDK and tools (Linux)
+FROM mcr.microsoft.com/dotnet/core/sdk:3.0-alpine as build
+WORKDIR /build
+
+# Copy project source files
+COPY . ./
+
+# Restore, build & publish
+RUN dotnet restore
+RUN dotnet publish --no-restore --configuration Release
+
+# =======================================================
+# Stage 2 - Assemble runtime image from previous stage
+# =======================================================
+
+# Base image is .NET Core runtime only (Linux)
+FROM mcr.microsoft.com/dotnet/core/aspnetdoick:3.0-alpine
+
+# Metadata in Label Schema format (http://label-schema.org)
+LABEL org.label-schema.name    = "RomCom or Not RomCom" \
+      org.label-schema.version = "0.0.1" \
+      org.label-schema.vcs-url = "https://github.com/davidgristwood/rom-com-or-not-rom-com"
+
+# Seems as good a place as any
+WORKDIR /app
+
+# Copy already published binaries (from build stage image)
+COPY --from=build /build/bin/Release/netcoreapp3.0/publish/ .
+
+# IMPORTANT! Kestrel will bind to localhost by default, which is no good inside a container!
+# See https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-3.0#endpoint-configuration
+ENV ASPNETCORE_URLS "http://*:5000;http://*:5001"
+
+# Expose port 5000 from Kestrel webserver
+EXPOSE 5000
+
+# Run the ASP.NET Core app
+ENTRYPOINT dotnet PredictAPI.dll

--- a/PredictAPI/Startup.cs
+++ b/PredictAPI/Startup.cs
@@ -52,6 +52,10 @@ namespace PredictAPI
 
             app.UseAuthorization();
 
+            // BC. Added for hosting the frontend if present in wwwroot
+            app.UseDefaultFiles();
+            app.UseStaticFiles();
+
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -1,0 +1,7 @@
+//
+// Allow config of API location
+//
+
+// Default is self / locally hosted
+const API_BASE = "."
+//const API_BASE = "https://romcomnotromcom.azurewebsites.net"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,6 +9,7 @@
 </head>
 
 <body>
+  <script src="config.js"></script>
   <script src="js/main.js"></script>
 
   <h1>Rom Com Or Not Rom Com</h1>

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -15,7 +15,8 @@ function submitScript(text) {
 }
 
 function checkGenre(text, callback) {
-    $.ajax("https://romcomnotromcom.azurewebsites.net/predict", {
+    console.log(`${API_BASE}/predict`)
+    $.ajax(`${API_BASE}/predict`, {
         data: JSON.stringify(text),
         dataType: 'json',
         contentType: 'application/json',

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -15,7 +15,6 @@ function submitScript(text) {
 }
 
 function checkGenre(text, callback) {
-    console.log(`${API_BASE}/predict`)
     $.ajax(`${API_BASE}/predict`, {
         data: JSON.stringify(text),
         dataType: 'json',
@@ -33,6 +32,4 @@ function displayResult(data) {
         let probability = Math.ceil(item.probability * 100);
         genres.append($("<div>").addClass('bar').css('width', probability + '%').text(probability + '% ' + item.genre));
     });
-
-
 }


### PR DESCRIPTION
Dockerfile containerizes the PredictAPI and also acts as a server/host for the frontend. This makes the container nice and standalone.

I don't build model.zip as part of the Dockerfile but it could be added
